### PR TITLE
Update to 0.2.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "archspec" %}
-{% set version = "0.2.1" %}
+{% set version = "0.2.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/archspec-{{ version }}.tar.gz
-  sha256: 0974a8a95831d2d43cce906c5b79a35d5fd2bf9be478b0e3b7d83ccc51ac815e
+  sha256: d07deb5b6e2ab3b74861e217523d02e69be8522f6e6565f4cc5d2062eb1a5d2c
 
 build:
   number: 0
@@ -19,10 +19,12 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python >=3.7
     - poetry-core
   run:
-    - python >=3.6
+    # According to the upstream `pyproject.toml`, python==3.6.15 is also
+    # supported, but including that here seems more trouble than it's worth.
+    - python >=3.7
 
 test:
   imports:


### PR DESCRIPTION
Update archspec 0.2.3

### Links

- Anaconda ticket: PKG-4176
- [Upstream repository](https://github.com/archspec/archspec)
- [Upstream changelog/diff](https://github.com/archspec/archspec/releases/tag/v0.2.3)
- [Upstream pyproject.tom](https://github.com/archspec/archspec/blob/v0.2.3/pyproject.toml)
- [Upstream whl metadata](https://inspector.pypi.io/project/archspec/0.2.3/packages/36/a6/7f0f500ce427b19c25f8cc05ee8cff9fb635373d62ae39e446d6f789e882/archspec-0.2.3-py3-none-any.whl/archspec-0.2.3.dist-info/METADATA)
