### PR TITLE
archspec 0.2.6 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,16 @@
 {% set name = "archspec" %}
-{% set version = "0.2.5" %}
+{% set version = "0.2.6" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/archspec-{{ version }}.tar.gz
-  sha256: 5bec8dfc5366ff299071200466dc9572d56db4e43abca3c66bdd62bc2b731a2a
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 2ea980955530499865225eff917b649b39fd014b53f8c6461b6348c1d8b866f1
 
 build:
   number: 0
-  noarch: python
   entry_points:
     - archspec = archspec.cli:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -19,12 +18,10 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.7
-    - poetry-core
+    - python
+    - poetry-core >=1.0.0
   run:
-    # According to the upstream `pyproject.toml`, python==3.6.15 is also
-    # supported, but including that here seems more trouble than it's worth.
-    - python >=3.7
+    - python
 
 test:
   imports:
@@ -37,15 +34,15 @@ test:
     - pip
 
 about:
-  home: https://pypi.org/project/archspec/
+  home: https://pypi.org/project/archspec
   summary: A library to query system architecture
   description: A library to query system architecture
   license: MIT OR Apache-2.0
   license_file:
     - LICENSE-MIT
     - LICENSE-APACHE
-  dev_url: https://github.com/archspec/archspec/
-  doc_url: https://archspec.readthedocs.io/
+  dev_url: https://github.com/archspec/archspec
+  doc_url: https://archspec.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
archspec 0.2.6 

**Destination channel:** Defaults

### Links

- [PKG-15500]
- dev_url:        https://github.com/archspec/archspec//tree/v0.2.6
- conda_forge:    https://github.com/conda-forge/archspec-feedstock
- pypi:           https://pypi.org/project/archspec/0.2.6
- pypi inspector: https://inspector.pypi.io/project/archspec/0.2.6

### Explanation of changes:

- new version number


[PKG-15500]: https://anaconda.atlassian.net/browse/PKG-15500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ